### PR TITLE
Generalize dotfiles for macOS support

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -8,3 +8,26 @@ just = "latest"
 lazydocker = "latest"
 lazygit = "latest"
 neovim = "latest"
+
+[shell_alias]
+# Neovim
+vim = "nvim"
+vi = "nvim"
+
+# lazygit & lazydocker
+lg = "lazygit"
+ld = "lazydocker"
+
+# fzf + bat (better file previewing)
+fzfp = 'fzf --preview "bat --color=always {}"'
+
+# jq pretty printing
+jq = "jq -C"
+
+# glow for markdown
+mdless = "glow"
+
+# Config shortcuts
+nvimcfg = "nvim ~/.config/nvim"
+zshcfg = "nvim ~/.zshrc"
+misecfg = "nvim ~/.config/mise/config.toml"

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -7,7 +7,7 @@ jq = "latest"
 just = "latest"
 lazydocker = "latest"
 lazygit = "latest"
-neovim = "latest"
+"core:neovim" = "latest"
 
 [shell_alias]
 # Neovim

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -33,6 +33,8 @@ jobs:
           touch ~/.zshrc
 
       - name: Run installation script
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash install.sh
 
@@ -42,6 +44,8 @@ jobs:
           mise --version
 
       - name: Verify tools are installed
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export PATH="${HOME}/.local/bin:${PATH}"
           eval "$(mise activate bash)"

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -53,11 +53,20 @@ jobs:
 
       - name: Verify dotfiles are linked
         run: |
-          test -L ~/.zsh_aliases && echo "✓ .zsh_aliases linked"
           test -L ~/.gitconfig && echo "✓ .gitconfig linked"
           test -L ~/.config/git/ignore && echo "✓ .gitignore_global linked"
           test -L ~/.config/mise/config.toml && echo "✓ mise config linked"
           test -L ~/.config/lazygit/config.yml && echo "✓ lazygit config linked"
+
+      - name: Verify shell aliases are configured
+        run: |
+          export PATH="${HOME}/.local/bin:${PATH}"
+          if grep -q '\[shell_alias\]' ~/.config/mise/config.toml; then
+            echo "✓ Shell aliases configured in mise"
+          else
+            echo "✗ Shell aliases not found in mise config"
+            exit 1
+          fi
 
       - name: Verify zsh integration
         run: |

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Run installation script
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash install.sh
 
@@ -46,6 +47,7 @@ jobs:
       - name: Verify tools are installed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export PATH="${HOME}/.local/bin:${PATH}"
           eval "$(mise activate bash)"

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -1,0 +1,65 @@
+name: Test Installation
+
+on:
+  push:
+    branches: [ main, claude/* ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  test-install:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup zsh (Ubuntu only)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zsh
+          # Create .zshrc if it doesn't exist
+          touch ~/.zshrc
+
+      - name: Setup zsh (macOS only)
+        if: runner.os == 'macOS'
+        run: |
+          # macOS comes with zsh, just ensure .zshrc exists
+          touch ~/.zshrc
+
+      - name: Run installation script
+        run: |
+          bash install.sh
+
+      - name: Verify mise is installed
+        run: |
+          export PATH="${HOME}/.local/bin:${PATH}"
+          mise --version
+
+      - name: Verify tools are installed
+        run: |
+          export PATH="${HOME}/.local/bin:${PATH}"
+          eval "$(mise activate bash)"
+          mise list
+
+      - name: Verify dotfiles are linked
+        run: |
+          test -L ~/.zsh_aliases && echo "✓ .zsh_aliases linked"
+          test -L ~/.gitconfig && echo "✓ .gitconfig linked"
+          test -L ~/.config/git/ignore && echo "✓ .gitignore_global linked"
+          test -L ~/.config/mise/config.toml && echo "✓ mise config linked"
+          test -L ~/.config/lazygit/config.yml && echo "✓ lazygit config linked"
+
+      - name: Verify zsh integration
+        run: |
+          if grep -q "dotfiles-setup" ~/.zshrc; then
+            echo "✓ zsh integration configured"
+          else
+            echo "✗ zsh integration not found"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ The script will automatically:
 
 ## Dev Container Setup
 
-### Prerequisites
+### Prerequisites (Optional)
 
-Add these features to your VS Code user settings in `dev.containers.defaultFeatures`:
+For faster setup in dev containers, you can pre-install mise via features in your VS Code user settings:
 
 ```json
 {
@@ -36,6 +36,8 @@ Add these features to your VS Code user settings in `dev.containers.defaultFeatu
   }
 }
 ```
+
+If mise is not pre-installed, the install script will automatically install it.
 
 ### VS Code Dotfiles Integration
 
@@ -65,10 +67,12 @@ The `github` backend works with any tool that publishes binaries to GitHub relea
 
 The install script:
 1. Detects your operating system (macOS or Linux)
-2. Installs mise if not already present (on macOS via the official installer)
+2. Installs mise if not already present (via the official installer)
 3. Symlinks `.config/mise/config.toml` to `~/.config/mise/config.toml` as your **global mise config**
 4. Installs all tools defined in the config
 5. Symlinks dotfiles (`.gitconfig`, `.zsh_aliases`, etc.) to your home directory
 6. Configures zsh integration for mise and aliases
 
 Your tools are available globally in all projects and directories, not just in specific project directories.
+
+**Note**: The script now installs mise automatically on all platforms, so you don't need to pre-install it or use the dev container feature. However, using the mise feature in dev containers is still recommended as it's faster.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,28 @@
-# devcontainer-dotfiles
+# dotfiles
 
-Personal dotfiles for dev containers. Uses [mise](https://mise.jdx.dev/).
+![Test Installation](https://github.com/lukewiwa/devcontainer-dotfiles/workflows/Test%20Installation/badge.svg)
 
-## Prerequisites
+Personal dotfiles for VS Code dev containers and macOS. Uses [mise](https://mise.jdx.dev/) for tool management.
+
+## macOS Setup
+
+On macOS, simply clone and run the install script:
+
+```bash
+git clone https://github.com/lukewiwa/devcontainer-dotfiles.git ~/.dotfiles
+cd ~/.dotfiles
+./install.sh
+```
+
+The script will automatically:
+- Install mise if not already present
+- Install all tools defined in `.config/mise/config.toml`
+- Symlink dotfiles to your home directory
+- Configure your zsh shell
+
+## Dev Container Setup
+
+### Prerequisites
 
 Add these features to your VS Code user settings in `dev.containers.defaultFeatures`:
 
@@ -17,7 +37,7 @@ Add these features to your VS Code user settings in `dev.containers.defaultFeatu
 }
 ```
 
-## Setup
+### VS Code Dotfiles Integration
 
 Add this to your VS Code settings (user settings, not workspace):
 
@@ -41,6 +61,14 @@ Edit `.config/mise/config.toml` to add new tools:
 
 The `github` backend works with any tool that publishes binaries to GitHub releases. For tools not on GitHub, mise also supports `aqua` and `cargo` backends.
 
-### How it works
+## How it works
 
-The install script symlinks `.config/mise/config.toml` to `~/.config/mise/config.toml`, making it the **global mise config**. This means your tools are available in all projects and directories within the dev container, not just when you're in a specific project directory.
+The install script:
+1. Detects your operating system (macOS or Linux)
+2. Installs mise if not already present (on macOS via the official installer)
+3. Symlinks `.config/mise/config.toml` to `~/.config/mise/config.toml` as your **global mise config**
+4. Installs all tools defined in the config
+5. Symlinks dotfiles (`.gitconfig`, `.zsh_aliases`, etc.) to your home directory
+6. Configures zsh integration for mise and aliases
+
+Your tools are available globally in all projects and directories, not just in specific project directories.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ cd ~/.dotfiles
 The script will automatically:
 - Install mise if not already present
 - Install all tools defined in `.config/mise/config.toml`
+- Activate shell aliases defined in mise config
 - Symlink dotfiles to your home directory
 - Configure your zsh shell
 
@@ -52,16 +53,21 @@ Add this to your VS Code settings (user settings, not workspace):
 
 That's it. VS Code will clone and run the install script automatically when creating dev containers.
 
-## Adding tools
+## Adding tools and aliases
 
-Edit `.config/mise/config.toml` to add new tools:
+Edit `.config/mise/config.toml` to add new tools or shell aliases:
 
 ```toml
 [tools]
 "github:your-org/your-tool" = "latest"
+
+[shell_alias]
+myalias = "your-command here"
 ```
 
 The `github` backend works with any tool that publishes binaries to GitHub releases. For tools not on GitHub, mise also supports `aqua` and `cargo` backends.
+
+Shell aliases are automatically activated by `mise activate zsh` and support all shell syntax.
 
 ## How it works
 
@@ -70,8 +76,9 @@ The install script:
 2. Installs mise if not already present (via the official installer)
 3. Symlinks `.config/mise/config.toml` to `~/.config/mise/config.toml` as your **global mise config**
 4. Installs all tools defined in the config
-5. Symlinks dotfiles (`.gitconfig`, `.zsh_aliases`, etc.) to your home directory
-6. Configures zsh integration for mise and aliases
+5. Activates shell aliases defined in the mise config
+6. Symlinks dotfiles (`.gitconfig`, `.gitignore_global`, lazygit config) to your home directory
+7. Configures zsh integration with `mise activate`
 
 Your tools are available globally in all projects and directories, not just in specific project directories.
 

--- a/install.sh
+++ b/install.sh
@@ -23,26 +23,18 @@ echo "Detected OS: $OS_NAME"
 # Install mise if not present
 if ! command -v mise &> /dev/null; then
     echo "mise not found, installing..."
+    echo "Installing mise via official installer..."
+    curl https://mise.run | sh
 
-    if [ "$OS_NAME" = "macOS" ]; then
-        # Install mise on macOS
-        echo "Installing mise via official installer..."
-        curl https://mise.run | sh
+    # Add mise to PATH for current session
+    export PATH="${HOME}/.local/bin:${PATH}"
 
-        # Add mise to PATH for current session
-        export PATH="${HOME}/.local/bin:${PATH}"
-
-        # Verify installation
-        if ! command -v mise &> /dev/null; then
-            echo "ERROR: mise installation failed"
-            exit 1
-        fi
-        echo "mise installed successfully"
-    else
-        # On Linux/dev containers, mise should be pre-installed via feature
-        echo "ERROR: mise not found. In dev containers, add the mise feature to your devcontainer.json"
+    # Verify installation
+    if ! command -v mise &> /dev/null; then
+        echo "ERROR: mise installation failed"
         exit 1
     fi
+    echo "mise installed successfully"
 else
     echo "mise already installed"
 fi

--- a/install.sh
+++ b/install.sh
@@ -3,12 +3,48 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-echo "Installing devcontainer dotfiles..."
+echo "Installing dotfiles..."
 
-# Verify mise is installed (should be via dev container feature)
+# Detect OS
+OS="$(uname -s)"
+case "$OS" in
+    Darwin*)
+        OS_NAME="macOS"
+        ;;
+    Linux*)
+        OS_NAME="Linux"
+        ;;
+    *)
+        OS_NAME="Unknown"
+        ;;
+esac
+echo "Detected OS: $OS_NAME"
+
+# Install mise if not present
 if ! command -v mise &> /dev/null; then
-    echo "ERROR: mise not found. Add the mise feature to your devcontainer.json"
-    exit 1
+    echo "mise not found, installing..."
+
+    if [ "$OS_NAME" = "macOS" ]; then
+        # Install mise on macOS
+        echo "Installing mise via official installer..."
+        curl https://mise.run | sh
+
+        # Add mise to PATH for current session
+        export PATH="${HOME}/.local/bin:${PATH}"
+
+        # Verify installation
+        if ! command -v mise &> /dev/null; then
+            echo "ERROR: mise installation failed"
+            exit 1
+        fi
+        echo "mise installed successfully"
+    else
+        # On Linux/dev containers, mise should be pre-installed via feature
+        echo "ERROR: mise not found. In dev containers, add the mise feature to your devcontainer.json"
+        exit 1
+    fi
+else
+    echo "mise already installed"
 fi
 
 # Link global mise config
@@ -60,7 +96,7 @@ link_file ".config/lazygit/config.yml" ".config/lazygit/config.yml"
 # Setup zsh integration
 setup_shell() {
     local shell_rc="${HOME}/.zshrc"
-    local marker="# devcontainer-dotfiles"
+    local marker="# dotfiles-setup"
 
     # Skip if already configured
     if grep -q "$marker" "$shell_rc" 2>/dev/null; then
@@ -71,7 +107,7 @@ setup_shell() {
     echo "Configuring zsh..."
     cat >> "$shell_rc" << EOF
 
-# devcontainer-dotfiles
+# dotfiles-setup
 export PATH="\${HOME}/.local/bin:\${PATH}"
 
 # mise

--- a/install.sh
+++ b/install.sh
@@ -80,7 +80,6 @@ link_file() {
     fi
 }
 
-link_file ".zsh_aliases"
 link_file ".gitconfig"
 link_file ".gitignore_global" ".config/git/ignore"
 link_file ".config/lazygit/config.yml" ".config/lazygit/config.yml"
@@ -102,11 +101,8 @@ setup_shell() {
 # dotfiles-setup
 export PATH="\${HOME}/.local/bin:\${PATH}"
 
-# mise
+# mise (provides tools, aliases, and environment)
 eval "\$(mise activate zsh)"
-
-# Aliases
-[ -f ~/.zsh_aliases ] && source ~/.zsh_aliases
 EOF
     echo "  Updated: $shell_rc"
 }

--- a/install.sh
+++ b/install.sh
@@ -20,14 +20,14 @@ case "$OS" in
 esac
 echo "Detected OS: $OS_NAME"
 
+# Ensure mise bin directory is in PATH
+export PATH="${HOME}/.local/bin:${PATH}"
+
 # Install mise if not present
 if ! command -v mise &> /dev/null; then
     echo "mise not found, installing..."
     echo "Installing mise via official installer..."
     curl https://mise.run | sh
-
-    # Add mise to PATH for current session
-    export PATH="${HOME}/.local/bin:${PATH}"
 
     # Verify installation
     if ! command -v mise &> /dev/null; then

--- a/install.sh
+++ b/install.sh
@@ -20,14 +20,14 @@ case "$OS" in
 esac
 echo "Detected OS: $OS_NAME"
 
-# Ensure mise bin directory is in PATH
-export PATH="${HOME}/.local/bin:${PATH}"
-
 # Install mise if not present
 if ! command -v mise &> /dev/null; then
     echo "mise not found, installing..."
     echo "Installing mise via official installer..."
     curl https://mise.run | sh
+
+    # Add mise to PATH for current session
+    export PATH="${HOME}/.local/bin:${PATH}"
 
     # Verify installation
     if ! command -v mise &> /dev/null; then


### PR DESCRIPTION
Add support for running the dotfiles setup on macOS in addition to dev
containers. The install script now:

- Detects the operating system (macOS vs Linux)
- Automatically installs mise on macOS if not present
- Uses OS-agnostic naming and messages throughout

Also add CI/CD pipeline to test installation on both Linux and macOS
via GitHub Actions.

Update README to document both macOS and dev container setup options.